### PR TITLE
Add number of classes to eval script

### DIFF
--- a/eval.sh
+++ b/eval.sh
@@ -10,5 +10,5 @@ galleryList_veri="./list/veri_test_list.txt"
 # Number of classes
 num_veri=576
 
-CUDA_VISIBLE_DEVICES=1 python -u eval.py $queryPath_veri $queryList_veri $galleryPath_veri $galleryList_veri --dataset veri --backbone resnet50 --weights './models/resnet50/Car_epoch_50.pth' --save_dir './results/veri/resnet50/'
+CUDA_VISIBLE_DEVICES=1 python -u eval.py $queryPath_veri $queryList_veri $galleryPath_veri $galleryList_veri -n $num_veri --dataset veri --backbone resnet50 --weights './models/resnet50/Car_epoch_50.pth' --save_dir './results/veri/resnet50/'
 


### PR DESCRIPTION
Unlike `train.sh`, `eval.sh` did not feature `num_veri` in the script. The fix would help in generalisability across datasets.